### PR TITLE
Improve certifications modal styling

### DIFF
--- a/frontend/src/components/sections/certifications/CertificationsModal.module.css
+++ b/frontend/src/components/sections/certifications/CertificationsModal.module.css
@@ -1,0 +1,194 @@
+/* Certifications Modal Styles - CSS Modules */
+
+/* Empty state inside modal */
+.adminEmpty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+  color: var(--md-sys-color-on-surface-variant);
+  gap: 0.5rem;
+}
+
+.adminEmpty i {
+  font-size: 2rem;
+  color: var(--md-sys-color-primary);
+}
+
+/* List container */
+.adminItemsList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+/* Item card */
+.adminItemCard {
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: box-shadow 0.2s ease;
+}
+
+.adminItemCard:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.adminItemHeader {
+  display: flex;
+  gap: 1rem;
+}
+
+.adminItemImage {
+  width: 60px;
+  height: 60px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.adminPlaceholderImage {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 1.5rem;
+}
+
+.adminItemImage img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.adminItemInfo {
+  flex: 1;
+}
+
+.adminItemInfo h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.adminItemSubtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--md-sys-color-primary);
+}
+
+.adminCertMetadata {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.adminItemDate,
+.adminItemCredential {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.adminItemActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.adminBtnSecondary,
+.adminBtnDanger {
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  font-size: 0.75rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  transition: background 0.2s;
+}
+
+.adminBtnSecondary {
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-primary);
+}
+
+.adminBtnSecondary:hover {
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.adminBtnDanger {
+  background: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container);
+}
+
+.adminBtnDanger:hover {
+  background: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
+}
+
+/* Form styles */
+.adminForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.adminFormRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.adminFormGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fullWidth {
+  grid-column: 1 / -1;
+}
+
+.adminFormGroup label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--md-sys-color-on-surface);
+}
+
+.adminFormGroup input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 6px;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+}
+
+.adminLoading {
+  text-align: center;
+  padding: 2rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.adminModalContent {
+  padding: 1rem;
+}

--- a/frontend/src/components/sections/certifications/CertificationsSection.tsx
+++ b/frontend/src/components/sections/certifications/CertificationsSection.tsx
@@ -5,6 +5,7 @@ import HeaderSection from "../header/HeaderSection";
 import AdminModal from "../../ui/AdminModal";
 import FloatingActionButtonGroup from "../../common/FloatingActionButtonGroup";
 import styles from "./CertificationsSection.module.css";
+import modalStyles from "./CertificationsModal.module.css";
 
 // Interfaz local para el componente con nombres amigables
 interface Certification {
@@ -180,7 +181,7 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
 
   const renderCertificationsList = () => {
     if (certifications.length === 0) {
-      return (        <div className={styles.adminEmpty}>
+      return (        <div className={modalStyles.adminEmpty}>
           <i className="fas fa-certificate"></i>
           <h3>No hay certificaciones</h3>
           <p>Añade la primera certificación usando el botón flotante.</p>
@@ -189,10 +190,10 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
     }
 
     return (
-      <div className={styles.adminItemsList}>
+      <div className={modalStyles.adminItemsList}>
         {certifications.map((cert) => (
-          <div key={cert.id} className={styles.adminItemCard}>            <div className={styles.adminItemHeader}>
-              <div className={styles.adminItemImage}>
+          <div key={cert.id} className={modalStyles.adminItemCard}>            <div className={modalStyles.adminItemHeader}>
+              <div className={modalStyles.adminItemImage}>
                 {cert.image ? (
                   <img
                     src={cert.image}
@@ -202,23 +203,23 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
                     }}
                   />
                 ) : (
-                  <div className={styles.adminPlaceholderImage}>
+                  <div className={modalStyles.adminPlaceholderImage}>
                     <i className="fas fa-certificate"></i>
                   </div>
                 )}
               </div>
               
-              <div className={styles.adminItemInfo}>
+              <div className={modalStyles.adminItemInfo}>
                 <h3>{cert.title}</h3>
-                <p className={styles.adminItemSubtitle}>{cert.issuer}</p>
+                <p className={modalStyles.adminItemSubtitle}>{cert.issuer}</p>
                 
-                <div className={styles.adminCertMetadata}>
-                  <div className={styles.adminItemDate}>
+                <div className={modalStyles.adminCertMetadata}>
+                  <div className={modalStyles.adminItemDate}>
                     <i className="fas fa-calendar-alt"></i>
                     <span>{cert.date}</span>
                   </div>
                   {cert.credentialId && (
-                    <div className={styles.adminItemCredential}>
+                    <div className={modalStyles.adminItemCredential}>
                       <i className="fas fa-id-card"></i>
                       <span>ID: {cert.credentialId}</span>
                     </div>
@@ -226,9 +227,9 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
                 </div>
               </div>
             </div>
-              <div className={styles.adminItemActions}>
+              <div className={modalStyles.adminItemActions}>
               <button 
-                className={styles.adminBtnSecondary}
+                className={modalStyles.adminBtnSecondary}
                 onClick={() => {
                   console.log("🔧 Edit button clicked for cert:", cert);
                   handleEditCertification({
@@ -246,8 +247,8 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
                 <i className="fas fa-edit"></i>
                 Editar
               </button>
-              <button 
-                className={styles.adminBtnDanger}
+              <button
+                className={modalStyles.adminBtnDanger}
                 onClick={() => {
                   console.log("🔧 Delete button clicked for cert:", cert.id, cert.title);
                   handleDeleteCertification(cert.id, cert.title);
@@ -264,9 +265,9 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
   };  const renderCertificationForm = () => {
     return (
       <div>        
-        <form onSubmit={handleCertificationSubmit} className={`${styles.adminForm} admin-form`}>
-          <div className={styles.adminFormRow}>
-            <div className={styles.adminFormGroup}>
+        <form onSubmit={handleCertificationSubmit} className={`${modalStyles.adminForm} admin-form`}>
+          <div className={modalStyles.adminFormRow}>
+            <div className={modalStyles.adminFormGroup}>
               <label htmlFor="cert-title">Título *</label>
               <input
                 type="text"
@@ -278,7 +279,7 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
                 placeholder="Ej: AWS Solutions Architect"
               />
             </div>
-            <div className={styles.adminFormGroup}>
+            <div className={modalStyles.adminFormGroup}>
               <label htmlFor="cert-issuer">Emisor *</label>
               <input
                 type="text"
@@ -292,8 +293,8 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
             </div>
           </div>
 
-          <div className={styles.adminFormRow}>
-            <div className={styles.adminFormGroup}>
+          <div className={modalStyles.adminFormRow}>
+            <div className={modalStyles.adminFormGroup}>
               <label htmlFor="cert-date">Fecha *</label>
               <input
                 type="text"
@@ -305,7 +306,7 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
                 placeholder="Ej: 2024, Enero 2024"
               />
             </div>
-            <div className={styles.adminFormGroup}>
+            <div className={modalStyles.adminFormGroup}>
               <label htmlFor="cert-credential">ID de Credencial</label>
               <input
                 type="text"
@@ -318,8 +319,8 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
             </div>
           </div>
 
-          <div className={styles.adminFormRow}>
-            <div className={`${styles.adminFormGroup} ${styles.fullWidth}`}>
+          <div className={modalStyles.adminFormRow}>
+            <div className={`${modalStyles.adminFormGroup} ${modalStyles.fullWidth}`}>
               <label htmlFor="cert-image">URL de Imagen</label>
               <input
                 type="url"
@@ -345,7 +346,7 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
     if (loading) {
       console.log("🔧 AdminModal - Mostrando loading...");
       return (
-        <div className={styles.adminLoading}>
+        <div className={modalStyles.adminLoading}>
           <i className="fas fa-spinner fa-spin"></i>
           <p>Cargando certificaciones...</p>
         </div>
@@ -552,7 +553,7 @@ const CertificationsSection: React.FC<CertificationsSectionProps> = ({
             }
           ]}
         >
-          <div className={styles.adminModalContent}>
+          <div className={modalStyles.adminModalContent}>
             {renderAdminContent()}
           </div>
         </AdminModal>


### PR DESCRIPTION
## Summary
- create new `CertificationsModal.module.css` with modern styles
- use the new module in `CertificationsSection` for admin modal lists and forms

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `npm run build --prefix frontend` *(fails: JSX element implicitly has type 'any')*

------
https://chatgpt.com/codex/tasks/task_e_68486d4adbb08322818a567079ef2551